### PR TITLE
Add pyink pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: pyink
+  name: pyink
+  description: "Pyink: a Python formatter forked from Black"
+  entry: pyink
+  language: python
+  minimum_pre_commit_version: 2.9.2
+  require_serial: true
+  types_or: [python, pyi]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ Code's `settings.json`:
 }
 ```
 
+## Can I use *Pyink* with the [pre-commit](https://pre-commit.com/) framework?
+
+Yes! You can put the following in your `.pre-commit-config.yaml` file:
+
+```yaml
+repos:
+  - repo: https://github.com/google/pyink
+    rev: 23.1.2
+    hooks:
+      - id: pyink
+        language_version: python3.8
+```
+
 # Why the name?
 
 We want a name with the same number of characters as *Black*, to make patching

--- a/README.md
+++ b/README.md
@@ -198,10 +198,14 @@ Yes! You can put the following in your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
   - repo: https://github.com/google/pyink
-    rev: 23.1.2
+    rev: 23.3.0
     hooks:
       - id: pyink
-        language_version: python3.8
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.9
 ```
 
 # Why the name?


### PR DESCRIPTION
Fixes #4

I tested this by running the pre-commit hook off my PR branch. I created a `pre-commi-config.yaml` file in a different repo:
```yaml
repos:
  - repo: https://github.com/jakevdp/pyink
    rev: 1ae7f2cf26282ef963bfeecb8fe285e1251fab56
    hooks:
      - id: pyink
        language_version: python3.8
```
And it ran successfully:
```bash
$ pre-commit run pyink --all-files
[INFO] Initializing environment for https://github.com/jakevdp/pyink.
[INFO] Installing environment for https://github.com/jakevdp/pyink.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
pyink....................................................................Failed
- hook id: pyink
- files were modified by this hook

reformatted setup.py
reformatted ml_dtypes/tests/custom_float_test.py

All done! ✨ 🍰 ✨
2 files reformatted, 1 file left unchanged.
```