### PR TITLE
fix(tox): use pyink instead of black in run_self env

### DIFF
--- a/src/pyink/ink.py
+++ b/src/pyink/ink.py
@@ -90,6 +90,7 @@ def unicode_escape_json(src: str) -> str:
     Returns:
       A serialized JSON string with unicode escaped characters.
     """
+
     def _match_to_unicode(match: re.Match[str]) -> str:
         char = match.group(0)
         return f"\\u{hex(ord(char))[2:].zfill(4)}"

--- a/src/pyink/ink_comments.py
+++ b/src/pyink/ink_comments.py
@@ -10,7 +10,7 @@ from pyink.mode import Mode
 
 
 def comment_contains_pragma(comment: str, mode: Optional[Mode]) -> bool:
-  """Check if the given string contains one of the pragma forms.
+    """Check if the given string contains one of the pragma forms.
 
     A pragma form can appear at the beginning of a comment:
       # pytype: disable=attribute-error
@@ -26,8 +26,8 @@ def comment_contains_pragma(comment: str, mode: Optional[Mode]) -> bool:
     Returns:
       True if the comment contains one of the pragma forms.
     """
-  if mode is None:
-    mode = Mode()
-  joined_pragma_expression = "|".join(mode.pyink_annotation_pragmas)
-  pragma_regex = re.compile(rf"([#|;] ?(?:{joined_pragma_expression}))")
-  return pragma_regex.search(comment) is not None
+    if mode is None:
+        mode = Mode()
+    joined_pragma_expression = "|".join(mode.pyink_annotation_pragmas)
+    pragma_regex = re.compile(rf"([#|;] ?(?:{joined_pragma_expression}))")
+    return pragma_regex.search(comment) is not None

--- a/src/pyink/linegen.py
+++ b/src/pyink/linegen.py
@@ -324,9 +324,9 @@ class LineGenerator(Visitor[Line]):
 
     def visit_suite(self, node: Node) -> Iterator[Line]:
         """Visit a suite."""
-        if (
-            self.mode.is_pyi or not self.mode.is_pyink
-        ) and is_stub_suite(node, self.mode):
+        if (self.mode.is_pyi or not self.mode.is_pyink) and is_stub_suite(
+            node, self.mode
+        ):
             yield from self.visit(node.children[2])
         else:
             yield from self.visit_default(node)

--- a/src/pyink/lines.py
+++ b/src/pyink/lines.py
@@ -1004,8 +1004,7 @@ def can_omit_invisible_parens(
         # conflict with type: ignore comments in the body
         if head_comments:
             has_type_ignore_in_head = any(
-                is_pragma_comment(comment, rhs.head.mode)
-                for comment in head_comments
+                is_pragma_comment(comment, rhs.head.mode) for comment in head_comments
             )
             has_other_comment_in_head = any(
                 not is_pragma_comment(comment, rhs.head.mode)

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -3057,15 +3057,12 @@ class TestFileCollection:
         assert result.stdout_bytes is not None
 
         stdout = self.decode_and_normalized(result.stdout_bytes)
-        assert (
-            """\
+        assert """\
 -from very.long.package.path.my_org.my_very_long_project_name.awesome_backend.core_framework.util import my_long_module_name
 +from very.long.package.path.my_org.my_very_long_project_name.awesome_backend.core_framework.util import (
 +    my_long_module_name,
 +)
-"""
-            in stdout
-        )
+""" in stdout
         assert "- pass\n+    pass\n" in stdout
 
     def test_pyink_in_tool_black(self) -> None:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -52,9 +52,16 @@ def check_file(subdir: str, filename: str, *, data: bool = True) -> None:
 @pytest.mark.parametrize(
     "filename",
     [
-        pytest.param(name, marks=pytest.mark.skip(reason="Skipping to suppress black incompatibility."))
-        if name in ["preview_comments7", "import_line_collapse"]
-        else name
+        (
+            pytest.param(
+                name,
+                marks=pytest.mark.skip(
+                    reason="Skipping to suppress black incompatibility."
+                ),
+            )
+            if name in ["preview_comments7", "import_line_collapse"]
+            else name
+        )
         for name in all_data_cases("cases")
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ setenv =
 skip_install = True
 commands =
     pip install -e .
-    black --check {toxinidir}
+    pyink --check {toxinidir}
 
 [testenv:generate_schema]
 setenv =


### PR DESCRIPTION
The run_self testenv is intended to verify that pyink can format its own source. It was incorrectly calling `black --check` instead of `pyink --check`, meaning the self-check was not actually exercising pyink's formatting rules.

Also reformatted the 6 files that pyink flagged as needing changes.