### PR TITLE
fix(tox): correct generate_schema output path to pyink resources

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,4 +63,4 @@ setenv =
 skip_install = True
 commands =
     pip install -e .
-    python {toxinidir}/scripts/generate_schema.py --outfile {toxinidir}/src/black/resources/black.schema.json
+    python {toxinidir}/scripts/generate_schema.py --outfile {toxinidir}/src/pyink/resources/pyink.schema.json


### PR DESCRIPTION
The generate_schema tox env was writing the generated schema to
src/black/resources/black.schema.json, which does not exist in this
repository. The correct path is src/pyink/resources/pyink.schema.json,
which is the file loaded at runtime by pyink/schema.py.