### PR TITLE
Fix EOFError on truncated cache, rename blk_ prefix, add Report.total_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,4 @@ See [CHANGES.md](./CHANGES.md).
 # Disclaimer
 
 This is not an officially supported Google product.
+

--- a/src/pyink/cache.py
+++ b/src/pyink/cache.py
@@ -79,7 +79,9 @@ class Cache:
             try:
                 data: dict[str, tuple[float, int, str]] = pickle.load(fobj)
                 file_data = {k: FileData(*v) for k, v in data.items()}
-            except (pickle.UnpicklingError, ValueError, IndexError):
+            except (pickle.UnpicklingError, ValueError, IndexError, EOFError):
+                # EOFError can occur when the cache file is truncated (e.g., due
+                # to a crash or interrupted write). Treat it as a cache miss.
                 return cls(mode, cache_file)
 
         return cls(mode, cache_file, file_data)

--- a/src/pyink/output.py
+++ b/src/pyink/output.py
@@ -113,7 +113,7 @@ def color_diff(contents: str) -> str:
 def dump_to_file(*output: str, ensure_final_newline: bool = True) -> str:
     """Dump `output` to a temporary file. Return path to the file."""
     with tempfile.NamedTemporaryFile(
-        mode="w", prefix="blk_", suffix=".log", delete=False, encoding="utf8"
+        mode="w", prefix="pyink_", suffix=".log", delete=False, encoding="utf8"
     ) as f:
         for lines in output:
             f.write(lines)

--- a/src/pyink/report.py
+++ b/src/pyink/report.py
@@ -33,6 +33,11 @@ class Report:
     same_count: int = 0
     failure_count: int = 0
 
+    @property
+    def total_count(self) -> int:
+        """Return the total number of files processed (changed + unchanged + failed)."""
+        return self.change_count + self.same_count + self.failure_count
+
     def done(self, src: Path, changed: Changed) -> None:
         """Increment the counter for successful reformatting. Write out a message."""
         if changed is Changed.YES:


### PR DESCRIPTION
- cache.py: Add EOFError to the except clause in Cache.read(). A truncated
  cache file (e.g. from a crash mid-write) previously raised an unhandled
  EOFError on startup; now it falls back to a cache miss gracefully.

- output.py: Rename temp file prefix from blk_ to pyink_. This was a
  leftover from the Black fork.

- report.py: Add a total_count property to Report, returning the sum of
  change_count + same_count + failure_count.